### PR TITLE
Changed date format to a more consistent format

### DIFF
--- a/PACore/Source/PlayAlways.swift
+++ b/PACore/Source/PlayAlways.swift
@@ -32,7 +32,7 @@ public struct PlayAlways {
     var dateString: String {
         let date = Date()
         let dateFormat = DateFormatter()
-        dateFormat.dateFormat = "Ymd_HMS"
+        dateFormat.dateFormat = "YMMdd_HHmmss"
         return dateFormat.string(from: date)
     }
     


### PR DESCRIPTION
The current format, `"Ymd_HMS"`, is essentially:
> Year, Minute(with no padding), Day (with no padding), _, Hour (with no padding), Month (with no padding), Fractional Seconds (with no padding)

Looking at this implies that the intention was for it to be `Date_Time`. But the current implementation leads to file names with no logical order.

This PR addresses this and changes the filename into:
> Year, 2 digit Month, 2 digit Day, underscore, 2 digit Hour, 2 digit Minutes, 2 digit Seconds

The benefits to this:
1. Padding means the filename sizes will be consistent.
2. Having the data in this order means an alphabetically sorted list of files is also in date order, making it easier to scan through the list of files to see which is the latest, the order they were created, etc.

Attached is a Playground showing these changes.
[PlayAlwaysFix.playground.zip](https://github.com/insidegui/PlayAlways/files/2912453/PlayAlwaysFix.playground.zip)
