### PR TITLE
Fixed date format

### DIFF
--- a/PACore/Source/PlayAlways.swift
+++ b/PACore/Source/PlayAlways.swift
@@ -32,7 +32,7 @@ public struct PlayAlways {
     var dateString: String {
         let date = Date()
         let dateFormat = DateFormatter()
-        dateFormat.dateFormat = "YMMdd_HHmmss"
+        dateFormat.dateFormat = "yMMdd_HHmmss"
         return dateFormat.string(from: date)
     }
     


### PR DESCRIPTION
Changing to using calendar year instead of `Year (in "Week of Year" based calendars)`, which lead to a bug with playgrounds made at the end of the year reporting as the following year.